### PR TITLE
feat: add stop condition to for_each_commit

### DIFF
--- a/include/cppgit2/repository.hpp
+++ b/include/cppgit2/repository.hpp
@@ -712,7 +712,7 @@ class repository : public libgit2_api {
 
   // Run operation for each commit in the repository
   void for_each_commit(
-      std::function<void(const commit& id)> visitor,
+      std::function<bool(const commit& id)> visitor,
       revision::sort sort_ordering = revision::sort::none) const;
 
   // Run operation for each commit in the repository

--- a/samples/print_commits.cpp
+++ b/samples/print_commits.cpp
@@ -10,6 +10,7 @@ int main(int argc, char** argv) {
       std::cout << c.id().to_hex_string(8) << " [" << c.committer().name()
                 << "]"
                 << " " << c.summary() << std::endl;
+      return true;
     });
 
   } else {

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -844,7 +844,7 @@ commit repository::lookup_commit(const oid& id, size_t length) const {
   return result;
 }
 
-void repository::for_each_commit(std::function<void(const commit& id)> visitor,
+void repository::for_each_commit(std::function<bool(const commit& id)> visitor,
                                  revision::sort sort_ordering) const {
   git_revwalk* iter;
   auto ret = git_revwalk_new(&iter, c_ptr_);
@@ -857,9 +857,10 @@ void repository::for_each_commit(std::function<void(const commit& id)> visitor,
 
   git_revwalk_sorting(iter, static_cast<unsigned int>(sort_ordering));
   git_oid id_c;
-  while ((ret = git_revwalk_next(&id_c, iter)) == 0) {
+  bool continue_iterating = true;
+  while ((ret = git_revwalk_next(&id_c, iter)) == 0 && continue_iterating) {
     oid id(&id_c);
-    visitor(lookup_commit(id));
+    continue_iterating = visitor(lookup_commit(id));
   }
   git_revwalk_free(iter);
 }


### PR DESCRIPTION
- Adds a way to stop iterating over all the commits in the
  for_each_commit function

Signed-off-by: Ricardo Benitez <benitezc.ricardo@gmail.com>
